### PR TITLE
Fix warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.vscode
 /log
 /Cargo.lock
+/.idea

--- a/src/sch/mod.rs
+++ b/src/sch/mod.rs
@@ -9,7 +9,6 @@ mod tree;
 mod tests;
 
 use async_trait::async_trait;
-use core::clone::Clone;
 
 use crate::event::ActionState;
 pub use crate::Result;

--- a/src/sch/state.rs
+++ b/src/sch/state.rs
@@ -1,4 +1,4 @@
-use core::{clone::Clone, convert::From, fmt};
+use core::{clone::Clone, fmt};
 use serde::{Deserialize, Serialize};
 
 use crate::{utils, Error};


### PR DESCRIPTION
warning: the item `From` is imported redundantly
   --> src/sch/state.rs:1:26
    |
1   | use core::{clone::Clone, convert::From, fmt};
    |                          ^^^^^^^^^^^^^
    |
    |
129 |     pub use core::prelude::rust_2021::*;
    |             ------------------------ the item `From` is already defined here
    |
    = note: `#[warn(unused_imports)]` on by default

warning: the item `Clone` is imported redundantly
   --> src/sch/mod.rs:12:5
    |
12  | use core::clone::Clone;
    |     ^^^^^^^^^^^^^^^^^^
    |
    |
125 |     pub use super::v1::*;
    |             --------- the item `Clone` is already defined here